### PR TITLE
去除多余<meta description>

### DIFF
--- a/layout/_partials/head/head.pug
+++ b/layout/_partials/head/head.pug
@@ -69,7 +69,6 @@ if theme.sougou_site_verification
 != open_graph()
 
 meta(name="keywords" content=keywords)
-meta(name="description" content=description)
 title= title
 
 if theme.canonical


### PR DESCRIPTION
hexo会自动生成<meta description>，此举去除多余<meta description>，避免搜索引擎降权