### PR TITLE
修复Chrome下zoom_image模糊的问题

### DIFF
--- a/source/css/_common/components/widgets/zoom-image.styl
+++ b/source/css/_common/components/widgets/zoom-image.styl
@@ -22,6 +22,6 @@
     z-index: $z-index2;
     background-color: #fff;
     cursor: zoom-out;
-    will-change: transform;
+    // will-change: transform;
   }
 }


### PR DESCRIPTION
See https://developers.google.com/web/updates/2016/09/re-rastering-composite for more details.
Close #246 .